### PR TITLE
Change libsecp256k1 library

### DIFF
--- a/lib/ex_wallet/wif.ex
+++ b/lib/ex_wallet/wif.ex
@@ -1,0 +1,23 @@
+defmodule ExWallet.Wif do
+  alias ExWallet.Base58
+  alias ExWallet.Extended.Private
+
+  @prefixes %{
+    main: <<0x80>>,
+    test: <<0xef>>
+  }
+
+  def priv_to_wif(key, network \\ :main)
+  def priv_to_wif(%Private{key: key}, network), do: priv_to_wif(key, network)
+  def priv_to_wif(key, network) when is_binary(key) do
+    key
+    |> prepend_symbol(network)
+    |> Base58.check_encode()
+  end
+
+  defp prepend_symbol(key, network) do
+    @prefixes
+    |> Map.get(network)
+    |> Kernel.<>(key)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule ExWallet.MixProject do
   defp deps do
     [
       {:poison, "~> 3.1"},
-      {:libsecp256k1, github: "mbrix/libsecp256k1", manager: :rebar}
+      {:libsecp256k1, "~> 0.1.10"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
-  "libsecp256k1": {:git, "https://github.com/mbrix/libsecp256k1.git", "671be513a6c19db47fbeea0ceefbf61421d196cc", []},
+  "libsecp256k1": {:hex, :libsecp256k1, "0.1.10", "d27495e2b9851c7765129b76c53b60f5e275bd6ff68292c50536bf6b8d091a4d", [:make, :mix], [{:mix_erlang_tasks, "0.1.0", [hex: :mix_erlang_tasks, repo: "hexpm", optional: false]}], "hexpm"},
+  "mix_erlang_tasks": {:hex, :mix_erlang_tasks, "0.1.0", "36819fec60b80689eb1380938675af215565a89320a9e29c72c70d97512e4649", [:mix], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
 }

--- a/test/ex_wallet/wif_test.exs
+++ b/test/ex_wallet/wif_test.exs
@@ -1,0 +1,27 @@
+defmodule ExWallet.WifTest do
+  use ExUnit.Case, async: true
+
+  alias ExWallet.Wif
+
+  # source of tests: https://en.bitcoin.it/wiki/Wallet_import_format
+  setup do
+    # Here we convert the hex representation of the private key, into a binary <<12, ...>>
+    hex_priv = "0C28FCA386C7A227600B2FE50B7CAE11EC86D3BF1FBE471BE89827E19D72AA1D"
+
+    priv =
+      for <<x::binary-2 <- hex_priv>> do
+        x
+      end
+      |> Enum.map(&String.to_integer(&1, 16))
+      |> Enum.reverse
+      |> Enum.reduce(<<>>, fn x, acc -> <<x>> <> acc end)
+
+    [priv: priv]
+  end
+
+  test "Converts private key into wallet import format", %{priv: priv} do
+    result = Wif.priv_to_wif(priv)
+
+    assert result == "5HueCGU8rMjxEXxiPuD5BDku4MkFqeZyd4dZ1jvhTVqvbTLvyTJ"
+  end
+end


### PR DESCRIPTION
We had some issue by installing ExWallet in recent OTP version, by using the hex version of the library worked for us. Can we change for that and release a new version for ExWallet?